### PR TITLE
specs.sh: Add missing "echo" commands

### DIFF
--- a/specs.sh
+++ b/specs.sh
@@ -4,9 +4,9 @@ echo Where is this runner?
 
 curl -s http://ip-api.com/json|jq
 
-Hostname: $(hostname)
+echo Hostname: $(hostname)
 
-Whoami: $(whoami)
+echo Whoami: $(whoami)
 
 echo lsblk
 


### PR DESCRIPTION
Hello @alexellis 

I was watching <https://www.youtube.com/live/CYCsa5e2vqg?feature=share&t=5045> and came across this repository.

Hope you don't mind if I propose a simple fix to the errors I noticed on lines 21-22 of
https://github.com/actuated-samples/specs/actions/runs/4558144575/jobs/8040672768